### PR TITLE
★に対応　など

### DIFF
--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -7,7 +7,7 @@
     emojis,
     defaultFFMpegArgs,
   } from "../lib/store";
-  import { getNote, splitEmojis } from "../lib/misskey";
+  import { getNote, splitEmojis, init } from "../lib/misskey";
 
   let noteId = "";
 
@@ -34,6 +34,7 @@
   const getNoteData = async () => {
     noteId = sanitizedNoteId;
     serverUrl.set(sanitizedServerUrl);
+    init();
 
     const noteData = await getNote(noteId);
     note.set(noteData);

--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -34,6 +34,7 @@
   const getNoteData = async () => {
     noteId = sanitizedNoteId;
     serverUrl.set(sanitizedServerUrl);
+    updateCookie();
     init();
 
     const noteData = await getNote(noteId);

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -15,16 +15,16 @@ const REPEATCHAR = "★"
 const EMOJINAME_REGEXP = /:([a-z0-9_+-]+):/i
 
 // 読み取りはこの順番に行われる。入れ替わりがあると正しく読み取られない
-const requestFields = [
-  ["①", (text, emoji) => emoji.name = text.match(EMOJINAME_REGEXP)[1]],
+const requestFields: [string, (text: string, emoji: Emoji) => void][] = [
+  ["①", (text, emoji) => emoji.name = text.match(EMOJINAME_REGEXP)![1]],
   ["②", (text, emoji) => emoji.license = text],
   ["③", (text, emoji) => emoji.from = text],
   ["④", (text, emoji) => emoji.description = text],
   ["⑤", (text, emoji) => emoji.tag = text.split(TAGSPLITCHAR)],
   // 以下docに定義なし フォーマットの定義が必要
   ["⑥", (text, emoji) => emoji.category = text],
-  ["⑦", (text, emoji) => emoji.isSensitive = !!text],
-  ["⑧", (text, emoji) => emoji.localOnly = !!text],
+  ["⑦", (text, emoji) => emoji.isSensitive = text],
+  ["⑧", (text, emoji) => emoji.localOnly = text],
 ];
 
 export const init = () => {
@@ -61,7 +61,9 @@ export const splitEmojis = (note: Note): Emoji[] => {
 
     const positions = [];
     for (const [numbering] of requestFields) {
-      const pos = emojiText.indexOf(numbering, positions.at(-1) ?? 0); 
+      const prevPosObj = positions.at(-1);
+      const prevPos = prevPosObj == null ? 0 : prevPosObj.pos + prevPosObj.skip;
+      const pos = emojiText.indexOf(numbering, prevPos); 
       if (pos === -1) break;
       positions.push({ pos, skip: numbering.length });
     }


### PR DESCRIPTION
- `★`による略記に対応します。
- その都合上、splitEmojis関数の構造が大きく変わりました。
- 申請ノートの読み取りの挙動が少し変わります。
  - 同行に複数の項目や一つの項目に複数行の表記が可能になりました。
    - [voskey docsのサンプル](https://voskeydocs.icalo.net/emoji/01-format/)のその1~3のような形式に対応するための措置です。
  - 代償として①～⑤の項目の並べ替えが不可能になりました。
 - https://github.com/uboar/misskey-emoji-register/pull/1 で`init()`と`updateCookie()`を入れ忘れていたことに気づいたので入れました。（ごめんなさい）