### PR TITLE
モバイル向けUI調整

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,7 +25,7 @@
 <main>
   <div class="h-screen w-screen">
     <div class="navbar bg-base-300">
-      <div class="navbar-start">
+      <div class="navbar-start w-full break-keep">
         <h1 class="text-xl">Misskey emoji Register</h1>
       </div>
     </div>

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  word-break: break-all;
+}

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -85,15 +85,22 @@
     roleIdsThatCanBeUsedThisEmojiAsReaction: [],
   };
 
-  let busy = false;
+  let sendEmojiError: string | null;
+
+  $: sendEmojiError = null;
+  $: busy = false;
   const sendEmoji = async (file: File) => {
     busy = true;
-    await addEmoji(sendEmojiData, file);
+    sendEmojiError = null;
+    await addEmoji(sendEmojiData, file).catch(e => {
+      console.error(e);
+      sendEmojiError = JSON.stringify(e, null, 2);
+    });
     busy = false;
   };
 </script>
 
-<div class="grid grid-cols-2 gap-2">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-2">
   <div class="card shadow-md">
     <div class="card-body">
       <div class="card-title text-lg">申請情報</div>
@@ -181,7 +188,7 @@
         <div class="join mt-4 flex-wrap">
           {#each Object.entries(FFmpegArgsTemplates) as [key, value]}
             <button
-              class="btn btn-outline join-item btn-sm"
+              class="btn btn-outline join-item btn-xs md:btn-sm"
               onclick={() => {
                 ffmpegArgs = value;
               }}>{key}</button
@@ -195,7 +202,7 @@
       >
         変換
       </button>
-      <div class="grid grid-cols-2">
+      <div class="grid grid-cols-1 md:grid-cols-2">
         <label class="form-control w-full">
           <input
             type="file"
@@ -210,7 +217,7 @@
           アップロード変換
         </button>
       </div>
-      <div class="grid grid-cols-2 gap-4 rounded-md bg-base-200 shadow">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4 rounded-md bg-base-200 shadow">
         <div class="m-4">
           変換前
           <img
@@ -286,7 +293,7 @@
 <div class="card shadow-md">
   <div class="card-body">
     <div class="card-title">登録</div>
-    <div class="grid grid-cols-2 gap-2">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
       <div>
         <div class="form-control">
           <label> <span class="label-text">ショートコード</span></label>
@@ -308,17 +315,32 @@
         </div>
 
         <div class="form-control">
-          <label> <span class="label-text">タグ</span>
+          <label> <span class="label-text">タグ</span> </label>
           <input
             id="tag"
             bind:value={taginput}
             type="text"
             class="input input-xs input-bordered md:input-md md:w-full"
+            placeholder="追加"
             onchange={() => {
               sendEmojiData.aliases = [...sendEmojiData.aliases!, taginput];
               taginput = "";
             }}
-          /></label>
+          />
+        </div>
+        <div class="flex flex-wrap gap-1 md:gap-4 pt-2">
+          {#each sendEmojiData.aliases! as tag, index}
+            <button
+              class="btn btn-outline btn-xs md:btn-sm rounded-full"
+              onclick={() => {
+                sendEmojiData.aliases!.splice(index, 1);
+                sendEmojiData.aliases = sendEmojiData.aliases;
+              }}
+            >
+              {tag}
+              <div class="badge badge-error">×</div>
+            </button>
+          {/each}
         </div>
       </div>
       <div>
@@ -331,7 +353,7 @@
             class="input input-xs input-bordered md:input-md md:w-full"
           />
         </div>
-        <div class="flex gap-8">
+        <div class="flex flex-col md:flex-row md:gap-8">
           <div class="form-control">
             <label class="label cursor-pointer">
               <span class="label-text m-4">センシティブ</span>
@@ -371,20 +393,9 @@
             }}>変換後を登録</button
           >
         </div>
-      </div>
-      <div class="flex flex-wrap gap-4">
-        {#each sendEmojiData.aliases! as tag, index}
-          <button
-            class="btn btn-outline btn-sm rounded-full"
-            onclick={() => {
-              sendEmojiData.aliases!.splice(index, 1);
-              sendEmojiData.aliases = sendEmojiData.aliases;
-            }}
-          >
-            {tag}
-            <div class="badge badge-error">×</div>
-          </button>
-        {/each}
+        {#if sendEmojiError}
+          <pre class="text-red-500 overflow-auto">{sendEmojiError}</pre>
+        {/if}
       </div>
     </div>
   </div>

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -104,16 +104,18 @@ export const splitEmojis = (note: Note): Emoji[] => {
   return emojis
 }
 
-export const addEmoji = async (request: AdminEmojiAddRequest, file: File) => {
-
-
+export const addEmoji = async (request: Omit<AdminEmojiAddRequest, 'file'>, file: File) => {
   const formData = new FormData();
   formData.append("i", get(accessToken));
   formData.append("file", file);
-  const createFile = await (await miApi.fetch(`${get(serverUrl)}/api/drive/files/create`, {
-    method: "POST", body: formData, headers: {},
-  })).json() as any as DriveFilesCreateResponse
-  if ('error' in createFile) throw createFile.error;
-  request.fileId = createFile.id;
-  await miApi.request("admin/emoji/add", request);
+
+  const res = await miApi.fetch(
+    `${get(serverUrl)}/api/drive/files/create`,
+    { method: "POST", body: formData, headers: {} }
+  ).then(res => res.json())// as any as DriveFilesCreateResponse
+  if ('error' in res) throw res.error;
+
+  await miApi.request("admin/emoji/add", {
+    ...request, fileId: res.id,
+  });
 }


### PR DESCRIPTION
絵文字登録画面を、スマートフォンから開いても一応使える程度にレスポンシブ化します。
## スクショ
### PC （ほぼ変化なし）
[before](https://github.com/user-attachments/assets/9fb3b70e-5aba-4da3-87eb-d163a69ce538)
[after](https://github.com/user-attachments/assets/108fafa1-8e45-4aa9-ae2b-b5c5593cfe2b)
### Mobile
[before](https://github.com/user-attachments/assets/2f511a4a-e698-40cc-967d-d517e569c503)
[after](https://github.com/user-attachments/assets/6c5d4937-cd83-4f6d-9f5c-472354df3641)