### PR TITLE
変更詰め合わせ(2)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - .
+allowBuilds:
+  esbuild: true

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,12 +4,12 @@
   import GetNote from "./components/GetNote.svelte";
   import EditNote from "./components/EditNote.svelte";
 
-  import { emojis, getCookie, note } from "./lib/store";
+  import { initStore, emojis, note } from "./lib/store";
   import { load } from "./lib/ffmpeg";
 
   let selectedTab: null | 'getnote' | 'editnote' | number = 'getnote';
 
-  getCookie();
+  initStore();
 
   onMount(async () => {
     await load();

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -50,7 +50,7 @@
           onclick={() => tabSelect(index)}
 	>
 	  <div class="min-w-4 flex flex-row">
-            <img class="w-4 object-contain" src={emoji.file.url} />
+            <img class="w-4 object-contain" src={emoji.file.url} alt=""/>
             <span class="px-2 whitespace-nowrap">:{emoji.name}:</span>
           </div>
 	</button>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-  import { onMount, tick } from "svelte";
+  import { onMount, tick, type SvelteComponent } from "svelte";
   import EmojiRegister from "./components/EmojiRegister.svelte";
   import GetNote from "./components/GetNote.svelte";
   import EditNote from "./components/EditNote.svelte";
+  import ToolsDialog from "./components/ToolsDialog.svelte";
 
   import { initStore, emojis, note } from "./lib/store";
   import { load } from "./lib/ffmpeg";
 
   let selectedTab: null | 'getnote' | 'editnote' | number = 'getnote';
+  let toolsDialog: ReturnType<typeof ToolsDialog>;
 
   initStore();
 
@@ -28,6 +30,13 @@
       <div class="navbar-start w-full break-keep">
         <h1 class="text-xl">Misskey emoji Register</h1>
       </div>
+      <button
+        class="navbar-end text-xl btn btn-ghost w-fit"
+        onclick={() => toolsDialog.show()}
+      >
+        🛠️<span class="hidden sm:inline">ツール</span>
+      </button>
+        <ToolsDialog bind:this={toolsDialog} />
     </div>
 
     <div role="tablist" class="tabs tabs-bordered bg-base-300 shadow overflow-auto">

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -26,12 +26,12 @@
     縦幅128px劣化圧縮GIFアニメ: "-vf scale=-1:128 -loop 0",
   };
 
-  const imageConvert = async () => {
+  const getImageByFetch = async () => {
     beforeConvertFile = await fetchImage(emoji.file.url);
     convertImage();
   };
 
-  const imageConvertFromClipboard = async () => {
+  const getImageFromClipboard = async () => {
     const clipboardData = await navigator.clipboard.read();
     let imageFile: File;
 
@@ -49,7 +49,7 @@
     }
   };
 
-  const imageConvertwithUpload = async () => {
+  const getImageWithUpload = async () => {
     beforeConvertFile = inputFile[0];
     convertImage();
   };
@@ -66,7 +66,7 @@
   }
     
   $: {
-    if (inputFile?.[0]) imageConvertwithUpload();
+    if (inputFile?.[0]) getImageWithUpload();
   }
 
   let beforewidth = 0;
@@ -207,14 +207,14 @@
       </div>
       <button
         class="btn btn-info btn-lg btn-block shadow"
-        onclick={imageConvert}
+        onclick={getImageByFetch}
       >
         変換
       </button>
       <div class="grid grid-cols-1 md:grid-cols-2">
         <button
           class="btn btn-warning btn-block h-full shadow"
-          onclick={imageConvertFromClipboard}
+          onclick={getImageFromClipboard}
         >
           クリップボードから変換
         </button>

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { defaultFFMpegArgs, note, serverUrl, type Emoji } from "../lib/store";
+  import { defaultFFMpegArgs, note, serverUrl, corsAnywhereUrl, type Emoji } from "../lib/store";
   import { get } from "svelte/store";
   import { convert } from "../lib/ffmpeg";
   import type { AdminEmojiAddRequest } from "misskey-js/entities.js";
@@ -212,12 +212,21 @@
           {/each}
         </div>
       </div>
-      <button
-        class="btn btn-info btn-lg btn-block shadow"
-        onclick={getImageByFetch}
-      >
-        変換
-      </button>
+      {#if get(corsAnywhereUrl)}
+        <button
+          class="btn btn-info btn-lg btn-block shadow"
+          onclick={getImageByFetch}
+        >
+          ワンクリック変換
+        </button>
+      {:else}
+        <button
+          class="btn btn-lg btn-block shadow text-sm"
+          disabled
+        >
+          ワンクリック変換にはcors-anywhere-urlが必要です
+        </button>
+      {/if}
       <div class="grid grid-cols-1 md:grid-cols-2">
         <button
           class="btn btn-warning btn-block h-full shadow"

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -89,7 +89,7 @@
     category: emoji.category,
     aliases: emoji.tag,
     license: `@${get(note).user.username} ${emoji.license}`,
-    isSensitive: emoji.isSensitive !== "",
+    isSensitive: emoji.file.isSensitive,
     localOnly: emoji.localOnly !== "",
     roleIdsThatCanBeUsedThisEmojiAsReaction: [],
   };
@@ -175,6 +175,13 @@
               ></td
             >
           </tr>
+          <tr>
+            <th>センシティブ</th>
+            <td
+              class:text-pink-400={emoji.file.isSensitive}
+            >{emoji.file.isSensitive ? "はい" : "いいえ"}</td>
+          </tr>
+          <tr>
         </tbody>
       </table>
     </div>

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -3,7 +3,7 @@
   import { get } from "svelte/store";
   import { convert } from "../lib/ffmpeg";
   import type { AdminEmojiAddRequest } from "misskey-js/entities.js";
-  import { addEmoji } from "../lib/misskey";
+  import { fetchImage, addEmoji } from "../lib/misskey";
 
   export let emoji: Emoji;
 
@@ -27,6 +27,11 @@
   };
 
   const imageConvert = async () => {
+    beforeConvertFile = await fetchImage(emoji.file.url);
+    convertImage();
+  };
+
+  const imageConvertFromClipboard = async () => {
     const clipboardData = await navigator.clipboard.read();
     let imageFile: File;
 
@@ -35,30 +40,34 @@
       if (item.types.includes(emoji.file.type)) {
         const blob = await item.getType(emoji.file.type);
 
-        const reader = new FileReader();
-        reader.addEventListener("load", () => {
-          beforeConvertImg.src = reader.result as string;
-        });
         beforeConvertFile = new File([blob], emoji.file.name, {
           type: emoji.file.type,
         });
-        reader.readAsDataURL(blob);
-        afterConvertFile = await convert(beforeConvertFile, ffmpegArgs);
-        if (afterConvertFile != null) {
-          afterConvertImg.src = URL.createObjectURL(afterConvertFile);
-        }
+        convertImage();
+        return;
       }
     }
   };
 
   const imageConvertwithUpload = async () => {
     beforeConvertFile = inputFile[0];
-    beforeConvertImg.src = URL.createObjectURL(beforeConvertFile);
-    afterConvertFile = await convert(beforeConvertFile, ffmpegArgs);
-    if (afterConvertFile != null) {
-      afterConvertImg.src = URL.createObjectURL(afterConvertFile);
-    }
+    convertImage();
   };
+
+  function convertImage() {
+    if (beforeConvertFile) {
+      beforeConvertImg.src = URL.createObjectURL(beforeConvertFile);
+      convert(beforeConvertFile, ffmpegArgs)
+        .then(v => {
+          afterConvertFile = v;
+          if (v) afterConvertImg.src = URL.createObjectURL(afterConvertFile);
+        });
+    }
+  }
+    
+  $: {
+    if (inputFile?.[0]) imageConvertwithUpload();
+  }
 
   let beforewidth = 0;
   let beforeheight = 0;
@@ -203,19 +212,27 @@
         変換
       </button>
       <div class="grid grid-cols-1 md:grid-cols-2">
-        <label class="form-control w-full">
-          <input
-            type="file"
-            bind:files={inputFile}
-            class="file-input file-input-bordered"
-          />
-        </label>
         <button
           class="btn btn-warning btn-block h-full shadow"
-          onclick={imageConvertwithUpload}
+          onclick={imageConvertFromClipboard}
         >
-          アップロード変換
+          クリップボードから変換
         </button>
+        <div>
+          <label
+            class="btn btn-warning btn-block h-full shadow"
+            for="input-upload-file"
+          >
+            アップロード変換
+          </label>
+          <input
+            type="file"
+            name="input-upload-file"
+            id="input-upload-file"
+            bind:files={inputFile}
+            hidden
+          />
+        </div>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4 rounded-md bg-base-200 shadow">
         <div class="m-4">

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -114,14 +114,14 @@
     <div class="card-body">
       <div class="card-title text-lg">申請情報</div>
       <div class="flex flex-wrap gap-2">
-        <img class="w-4 bg-black object-contain" src={emoji.file.url} />
-        <img class="w-4 bg-white object-contain" src={emoji.file.url} />
-        <img class="w-8 bg-black object-contain" src={emoji.file.url} />
-        <img class="w-8 bg-white object-contain" src={emoji.file.url} />
-        <img class="w-16 bg-black object-contain" src={emoji.file.url} />
-        <img class="w-16 bg-white object-contain" src={emoji.file.url} />
-        <img class="w-32 bg-black object-contain" src={emoji.file.url} />
-        <img class="w-32 bg-white object-contain" src={emoji.file.url} />
+        <img class="w-4 bg-black object-contain" src={emoji.file.url} alt="original emoji: bg-black w-4" />
+        <img class="w-4 bg-white object-contain" src={emoji.file.url} alt="original emoji: bg-white w-4" />
+        <img class="w-8 bg-black object-contain" src={emoji.file.url} alt="original emoji: bg-black w-8" />
+        <img class="w-8 bg-white object-contain" src={emoji.file.url} alt="original emoji: bg-white w-8" />
+        <img class="w-16 bg-black object-contain" src={emoji.file.url} alt="original emoji: bg-black w-16" />
+        <img class="w-16 bg-white object-contain" src={emoji.file.url} alt="original emoji: bg-white w-16" />
+        <img class="w-32 bg-black object-contain" src={emoji.file.url} alt="original emoji: bg-black w-32" />
+        <img class="w-32 bg-white object-contain" src={emoji.file.url} alt="original emoji: bg-white w-32" />
       </div>
       <table class="table table-zebra table-fixed">
         <tbody>
@@ -194,7 +194,7 @@
         GIFアニメは一度画像をダウンロードしてからアップロード変換を選択して下さい
       </div>
       <div>
-        <label>ffmpeg引数</label>
+        <label for="ffmpeg-args">ffmpeg引数</label>
         <input
           id="ffmpeg-args"
           bind:value={ffmpegArgs}
@@ -257,6 +257,7 @@
             bind:this={beforeConvertImg}
             class="w-32 bg-black object-contain"
             onload={beforeConvertLoaded}
+            alt="before conversion"
           />
           {#if beforeConvertFile != null}
             <table class="table">
@@ -291,6 +292,7 @@
             bind:this={afterConvertImg}
             class="w-32 bg-black object-contain"
             onload={afterConvertLoaded}
+            alt="after conversion"
           />
           {#if afterConvertFile != null}
             <table class="table">
@@ -329,7 +331,7 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
       <div>
         <div class="form-control">
-          <label> <span class="label-text">ショートコード</span></label>
+          <label for="name"> <span class="label-text">ショートコード</span></label>
           <input
             id="name"
             bind:value={sendEmojiData.name}
@@ -338,7 +340,7 @@
           />
         </div>
         <div class="form-control">
-          <label> <span class="label-text">ライセンス</span></label>
+          <label for="license"> <span class="label-text">ライセンス</span></label>
           <input
             id="license"
             bind:value={sendEmojiData.license}
@@ -348,7 +350,7 @@
         </div>
 
         <div class="form-control">
-          <label> <span class="label-text">タグ</span> </label>
+          <label for="tag"> <span class="label-text">タグ</span> </label>
           <input
             id="tag"
             bind:value={taginput}
@@ -378,7 +380,7 @@
       </div>
       <div>
         <div class="form-control">
-          <label> <span class="label-text">カテゴリー</span></label>
+          <label for="category"> <span class="label-text">カテゴリー</span></label>
           <input
             id="category"
             bind:value={sendEmojiData.category}

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -212,7 +212,7 @@
           {/each}
         </div>
       </div>
-      {#if get(corsAnywhereUrl)}
+      {#if $corsAnywhereUrl}
         <button
           class="btn btn-info btn-lg btn-block shadow"
           onclick={getImageByFetch}

--- a/src/components/EmojiRegister.svelte
+++ b/src/components/EmojiRegister.svelte
@@ -27,7 +27,7 @@
   };
 
   const getImageByFetch = async () => {
-    beforeConvertFile = await fetchImage(emoji.file.url);
+    beforeConvertFile = await fetchImage(emoji.file.url, emoji.file.name);
     convertImage();
   };
 

--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -3,7 +3,6 @@
     accessToken,
     serverUrl,
     note,
-    updateCookie,
     emojis,
     defaultFFMpegArgs,
   } from "../lib/store";
@@ -38,8 +37,6 @@
   const getNoteData = async () => {
     noteId = sanitizedNoteId;
     serverUrl.set(sanitizedServerUrl);
-    updateCookie();
-    init();
 
     const noteData = await getNote(noteId);
     note.set(noteData);
@@ -58,7 +55,6 @@
       type="text"
       class="input input-xs input-bordered md:input-md md:w-64"
       placeholder="EX: https://voskey.icalo.net"
-      oninput={updateCookie}
     />
     {#if $serverUrl !== sanitizedServerUrl}
       <div class="mt-1 text-sm">
@@ -79,7 +75,6 @@
       bind:value={$accessToken}
       type="password"
       class="input input-xs input-bordered md:input-md md:w-64"
-      oninput={updateCookie}
     />
     {#if $serverUrl}
       <button
@@ -108,7 +103,6 @@
       bind:value={noteId}
       type="text"
       class="input input-xs input-bordered md:input-md md:w-64"
-      oninput={updateCookie}
     />
     {#if noteId !== sanitizedNoteId}
       <div class="mt-1 text-sm">
@@ -130,7 +124,6 @@
       type="text"
       class="input input-xs input-bordered md:input-md md:w-64"
       placeholder="EX: -lossless 1"
-      oninput={updateCookie}
     />
   </div>
   <button class="btn btn-primary" onclick={getNoteData}>ノート取得</button>

--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -84,7 +84,10 @@
     {#if $serverUrl}
       <button
         class="btn btn-xs inline-block"
-        onclick={() => open(miauth.getUrl())}
+        onclick={() => {
+	  serverUrl.set(sanitizedServerUrl);
+	  open(miauth.getUrl());
+        }}
       >
         認証でトークンを生成
       </button>

--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -7,7 +7,7 @@
     defaultFFMpegArgs,
     corsAnywhereUrl,
   } from "../lib/store";
-  import { getNote, init } from "../lib/misskey";
+  import { getNote } from "../lib/misskey";
   import { splitEmojis } from "../lib/splitEmojis";
   import { MiAuth } from "../lib/miauth.svelte";
 

--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -49,7 +49,7 @@
 
 <div class="grid gap-4">
   <div>
-    <label for="server-url">サーバーURL</label>
+    <label for="server-url">サーバーURL<span class="text-red-400">*</span></label>
     <input
       id="server-url"
       bind:value={$serverUrl}
@@ -70,7 +70,7 @@
     {/if}
   </div>
   <div>
-    <label for="access-token">アクセストークン</label>
+    <label for="access-token">アクセストークン<span class="text-red-400">*</span></label>
     <input
       id="access-token"
       bind:value={$accessToken}
@@ -98,7 +98,7 @@
     {/if}
   </div>
   <div>
-    <label for="note-id">ノートID</label>
+    <label for="note-id">ノートID<span class="text-red-400">*</span></label>
     <input
       id="note-id"
       bind:value={noteId}
@@ -137,7 +137,11 @@
       placeholder="EX: https://example-cors-anywhere.com"
     />
   </div>
-  <button class="btn btn-primary" onclick={getNoteData}>ノート取得</button>
+  <button
+    class="btn btn-primary"
+    onclick={getNoteData}
+    disabled={!($serverUrl && $accessToken && noteId)}
+  >ノート取得</button>
   <textarea
     class="textarea textarea-bordered"
     readonly

--- a/src/components/GetNote.svelte
+++ b/src/components/GetNote.svelte
@@ -5,6 +5,7 @@
     note,
     emojis,
     defaultFFMpegArgs,
+    corsAnywhereUrl,
   } from "../lib/store";
   import { getNote, init } from "../lib/misskey";
   import { splitEmojis } from "../lib/splitEmojis";
@@ -124,6 +125,16 @@
       type="text"
       class="input input-xs input-bordered md:input-md md:w-64"
       placeholder="EX: -lossless 1"
+    />
+  </div>
+  <div>
+    <label for="default-ffmpeg-args">cors-anywhere URL</label>
+    <input
+      id="cors-anywhere-url"
+      bind:value={$corsAnywhereUrl}
+      type="text"
+      class="input input-xs input-bordered md:input-md md:w-64"
+      placeholder="EX: https://example-cors-anywhere.com"
     />
   </div>
   <button class="btn btn-primary" onclick={getNoteData}>ノート取得</button>

--- a/src/components/ToolsDialog.svelte
+++ b/src/components/ToolsDialog.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+import { miApiReady, getEmojisBulk, deleteEmojis } from '../lib/misskey';
+
+export function show() {
+  dialogRoot.show();
+}
+
+let dialogRoot: HTMLDialogElement;
+let deleteEmojisText = $state('');
+let deleteEmojisFetched = $state<
+  Awaited<ReturnType<typeof getEmojisBulk>>
+>([]);
+let deleteEmojisJsonUrl = $state('');
+let deleteEmojisFileName = $state('');
+let deleteEmojisBackupDone = $state(false);
+let deleteEmojisDone = $state(false);
+
+async function fetchDeletedEmojis() {
+  deleteEmojisFetched = await getEmojisBulk(deleteEmojisText);
+}
+
+$effect(() => {
+  const json = JSON.stringify(deleteEmojisFetched);
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  deleteEmojisJsonUrl = url;
+  deleteEmojisFileName = [
+    'EmojiBackup (',
+    deleteEmojisFetched.length === 0 ? 'empty' : [
+      deleteEmojisFetched[0].name,
+      deleteEmojisFetched.length === 1 ? [] : [
+        ` and ${deleteEmojisFetched.length - 1} emojis`,
+      ],
+    ],
+    ').json',
+  ].flat().join('')
+  deleteEmojisBackupDone = false;
+  deleteEmojisDone = false;
+  return () => URL.revokeObjectURL(url);
+});
+</script>
+<dialog bind:this={dialogRoot} class="modal">
+  <div class="modal-box">
+    <div class="text-xl">ツール</div>
+    <div class="divider"></div>
+    <div class="text-lg">絵文字一括削除</div>
+    <form method="dialog">
+      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+    </form>
+    <textarea
+      class="textarea textarea-bordered h-32 w-full"
+      disabled={!$miApiReady}
+      bind:value={deleteEmojisText}
+    ></textarea>
+    {#if $miApiReady}
+      <div class="text-xs">削除する絵文字名が<code>::</code>で挟まれているテキストを貼り付けてください</div>
+      <button
+        class="btn"
+        disabled={deleteEmojisText === ""}
+        onclick={fetchDeletedEmojis}
+      >絵文字情報取得</button>
+      {#if deleteEmojisFetched.length !== 0}
+        <div class="text-xs">以下の絵文字が削除されます</div>
+        <table class="table table-zebra">
+          <thead>
+            <tr>
+              <th>画像</th>
+              <th>ライセンス</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each deleteEmojisFetched as emoji}
+              <tr>
+                <td><img class="h-8 inline-block" src={emoji.url} alt={`:${emoji.name}:`} /></td>
+                <td>{emoji.license}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+        <div class="text-sm">
+          先に絵文字データのバックアップを取ってください。
+          <a
+            class="btn btn-xs inline-block"
+            href={deleteEmojisJsonUrl}
+            download={deleteEmojisFileName}
+            onclick={() => deleteEmojisBackupDone = true}
+          >
+            ダウンロード
+          </a>
+        </div>
+        <button
+          class="btn btn-primary"
+          disabled={!deleteEmojisBackupDone || deleteEmojisDone}
+          onclick={() => deleteEmojis(deleteEmojisFetched).then(() => deleteEmojisDone = true)}
+        >削除を実行</button>
+        {#if deleteEmojisDone}削除完了{/if}
+      {/if}
+    {:else}
+      <div class="text-xs">絵文字一括削除ツールを使用するにはトップページでサーバーURLとアクセストークンを入力してください</div>
+    {/if}
+  </div>
+  <!-- 背景クリックで閉じれるようにするやつ -->
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/src/lib/miauth.svelte.ts
+++ b/src/lib/miauth.svelte.ts
@@ -18,7 +18,7 @@ export class MiAuth {
       this.sessionId = null;
       unsubscribe();
     });
-    return `${get(serverUrl)}/miauth/${this.sessionId}?name=misskey-emoji-register&permission=write:drive,write:admin:emoji`;
+    return `${get(serverUrl)}/miauth/${this.sessionId}?name=misskey-emoji-register&permission=write:drive,read:admin:emoji,write:admin:emoji`;
   }
   async requestToken(): Promise<void> {
     if (this.sessionId == null) throw new Error("token is not ready");

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -1,9 +1,10 @@
 import { api } from "misskey-js"
 
 import { serverUrl, accessToken, corsAnywhereUrl } from "./store";
+import { EMOJINAME_REGEXP1 } from './splitEmojis';
 import { get, derived } from "svelte/store";
 import type { APIClient } from "misskey-js/api.js";
-import type { AdminEmojiAddRequest, DriveFilesCreateResponse, Note } from "misskey-js/entities.js";
+import type { AdminEmojiAddRequest, DriveFilesCreateResponse, Note, EmojiDetailed  } from "misskey-js/entities.js";
 
 const miApi = derived(
   [serverUrl, accessToken],
@@ -11,6 +12,11 @@ const miApi = derived(
     origin: $serverUrl,
     credential: $accessToken,
   }),
+);
+
+export const miApiReady = derived(
+  [serverUrl, accessToken],
+  ([$serverUrl, $accessToken]) => ($serverUrl && $accessToken),
 );
 
 export const getNote = async (noteId: string): Promise<Note> => {
@@ -46,4 +52,30 @@ export async function fetchImage(url: string, filename: string): Promise<File> {
   const blob = await response.blob();
 
   return new File([blob], filename, { type: blob.type });
+}
+
+export async function getEmojisBulk(rawQuery: string): Promise<EmojiDetailed[]> {
+  const re = new RegExp(EMOJINAME_REGEXP1, 'g');
+  const query = [...rawQuery.matchAll(re)].map(m => m[0]).join('');
+  if (query === '') return [];
+
+  let emojis: EmojiDetailed[] = [];
+  let untilId: string | null = null;
+  for (;;) {
+    const newEmojis = await get(miApi).request("admin/emoji/list", {
+      query,
+      limit: 100,
+      ...(untilId !== null ? { untilId } : {}),
+    }) as EmojiDetailed[]; // misskey-jsが古くなっており型が合わないためasでごまかす
+    if (newEmojis.length === 0) break;
+    emojis = emojis.concat(newEmojis);
+    untilId = newEmojis.at(-1)!.id;
+  }
+  return emojis;
+}
+
+export async function deleteEmojis(emojis: EmojiDetailed[]) {
+  await get(miApi).request("admin/emoji/delete-bulk", {
+    ids: emojis.map(v => v.id),
+  });
 }

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -38,7 +38,7 @@ export const addEmoji = async (request: Omit<AdminEmojiAddRequest, 'file'>, file
   });
 }
 
-export async function fetchImage(url: string): Promise<File> {
+export async function fetchImage(url: string, filename: string): Promise<File> {
   const response = await fetch(get(corsAnywhereUrl) + url);
   if (!response.ok) {
     throw new Error(`画像の取得に失敗しました: ${response.status}`);
@@ -46,16 +46,5 @@ export async function fetchImage(url: string): Promise<File> {
 
   const blob = await response.blob();
 
-  // URLからファイル名を抽出
-  const urlObj = new URL(url);
-  let fileName = urlObj.pathname.split('/').pop() || 'downloaded_image';
-
-  // ファイル名に拡張子が含まれていない場合、MIMEタイプから拡張子を推測
-  if (!fileName.includes('.')) {
-    const mimeType = blob.type;
-    const extension = mimeType.split('/').pop();
-    fileName += `.${extension}`;
-  }
-
-  return new File([blob], fileName, { type: blob.type });
+  return new File([blob], filename, { type: blob.type });
 }

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -37,3 +37,25 @@ export const addEmoji = async (request: Omit<AdminEmojiAddRequest, 'file'>, file
     ...request, fileId: res.id,
   });
 }
+
+export async function fetchImage(url: string): Promise<File> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`画像の取得に失敗しました: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+
+  // URLからファイル名を抽出
+  const urlObj = new URL(url);
+  let fileName = urlObj.pathname.split('/').pop() || 'downloaded_image';
+
+  // ファイル名に拡張子が含まれていない場合、MIMEタイプから拡張子を推測
+  if (!fileName.includes('.')) {
+    const mimeType = blob.type;
+    const extension = mimeType.split('/').pop();
+    fileName += `.${extension}`;
+  }
+
+  return new File([blob], fileName, { type: blob.type });
+}

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -1,6 +1,6 @@
 import { api } from "misskey-js"
 
-import { serverUrl, accessToken } from "./store";
+import { serverUrl, accessToken, corsAnywhereUrl } from "./store";
 import { get } from "svelte/store";
 import type { APIClient } from "misskey-js/api.js";
 import type { AdminEmojiAddRequest, DriveFilesCreateResponse, Note } from "misskey-js/entities.js";
@@ -39,7 +39,7 @@ export const addEmoji = async (request: Omit<AdminEmojiAddRequest, 'file'>, file
 }
 
 export async function fetchImage(url: string): Promise<File> {
-  const response = await fetch(url);
+  const response = await fetch(get(corsAnywhereUrl) + url);
   if (!response.ok) {
     throw new Error(`画像の取得に失敗しました: ${response.status}`);
   }

--- a/src/lib/misskey.ts
+++ b/src/lib/misskey.ts
@@ -1,21 +1,20 @@
 import { api } from "misskey-js"
 
 import { serverUrl, accessToken, corsAnywhereUrl } from "./store";
-import { get } from "svelte/store";
+import { get, derived } from "svelte/store";
 import type { APIClient } from "misskey-js/api.js";
 import type { AdminEmojiAddRequest, DriveFilesCreateResponse, Note } from "misskey-js/entities.js";
 
-let miApi: APIClient;
-
-export const init = () => {
-  miApi = new api.APIClient({
-    origin: get(serverUrl),
-    credential: get(accessToken),
-  })
-}
+const miApi = derived(
+  [serverUrl, accessToken],
+  ([$serverUrl, $accessToken]) => new api.APIClient({
+    origin: $serverUrl,
+    credential: $accessToken,
+  }),
+);
 
 export const getNote = async (noteId: string): Promise<Note> => {
-  const note = miApi.request("notes/show", {
+  const note = get(miApi).request("notes/show", {
     noteId
   })
 
@@ -27,13 +26,13 @@ export const addEmoji = async (request: Omit<AdminEmojiAddRequest, 'file'>, file
   formData.append("i", get(accessToken));
   formData.append("file", file);
 
-  const res = await miApi.fetch(
+  const res = await get(miApi).fetch(
     `${get(serverUrl)}/api/drive/files/create`,
     { method: "POST", body: formData, headers: {} }
   ).then(res => res.json())// as any as DriveFilesCreateResponse
   if ('error' in res) throw res.error;
 
-  await miApi.request("admin/emoji/add", {
+  await get(miApi).request("admin/emoji/add", {
     ...request, fileId: res.id,
   });
 }

--- a/src/lib/splitEmojis.ts
+++ b/src/lib/splitEmojis.ts
@@ -5,7 +5,7 @@ const NAMECHAR = "①"
 const SPLITCHAR = "▼"
 const TAGSPLITCHAR = /(?: |　|\n)+/
 const REPEATCHAR_REGEXP = /^(★|☆)$/
-const EMOJINAME_REGEXP1 = /:([a-z0-9_+-]+):/i
+export const EMOJINAME_REGEXP1 = /:([a-z0-9_+-]+):/i
 const EMOJINAME_REGEXP2 = /[a-z0-9_+-]+/i
 
 // 読み取りはこの順番に行われる。入れ替わりがあると正しく読み取られない

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,5 @@
 import { writable, get } from "svelte/store";
 import type { Writable } from "svelte/store";
-import { init as apiInit } from "./misskey";
 import type { DriveFile, Note } from "misskey-js/entities.js";
 
 export type Emoji = {
@@ -42,10 +41,8 @@ export const getCookie = () => {
   for (const [key, store] of Object.entries(cookieStoresRecord)) {
     store.subscribe(value => {
       document.cookie = `${key}=${value}; Max-Age=50000000`;
-      apiInit();
     });
   }
-  apiInit();
 }
 
 // 機密でもない情報　設定系

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -20,10 +20,11 @@ export const serverUrl = writable("");
 export const accessToken = writable("");
 export const note = writable<Note>();
 export const defaultFFMpegArgs = writable("-lossless 1");
+export const corsAnywhereUrl = writable("");
 export const emojis = writable<Emoji[]>();
 
 const cookieStoresRecord: Record<string, Writable<string>> = {
-  serverUrl, accessToken, defaultFFMpegArgs
+  serverUrl, accessToken, defaultFFMpegArgs, corsAnywhereUrl
 };
 
 export const getCookie = () => {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -26,7 +26,7 @@ export const emojis = writable<Emoji[]>();
 const cookieStoresRecord: Record<string, Writable<string>> = {
   accessToken,
 };
-export const getCookie = () => {
+const getCookie = () => {
   const cookies = document.cookie;
   if (cookies !== "") {
     const strArr = cookies.split("; ");
@@ -53,4 +53,41 @@ for (const [key, store] of Object.entries(storageStoresRecord)) {
   const saved = localStorage.getItem(key);
   if (saved != null) store.set(saved);
   store.subscribe(value => localStorage.setItem(key, value));
+}
+function loadQueryParam(): void {
+  const url = new URL(window.location.href);
+  const params = new URLSearchParams(url.search);
+  let doKeep = false;
+  for (const [qpkey, qpvalue] of params) {
+    if (Object.hasOwn(storageStoresRecord, qpkey)) {
+      storageStoresRecord[qpkey].set(qpvalue);
+      continue;
+    }
+    switch (qpkey) {
+      case 'load': {
+        const newParams = new URLSearchParams();
+        for (const [k, st] of Object.entries(storageStoresRecord)) {
+          newParams.append(k, get(st));
+        }
+        url.search = newParams.toString();
+        window.history.replaceState(null, '', url.toString());
+        doKeep = true;
+        break;
+      }
+      case 'keep': {
+        doKeep = !!qpvalue;
+        break;
+      }
+      default: {
+        console.error(`Unknown Query Param: ${qpkey}`);
+        break;
+      }
+    }
+  }
+  if (!doKeep) window.history.replaceState(null, '', url.pathname);
+}
+
+export function initStore(): void {
+  getCookie();
+  loadQueryParam();
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -23,10 +23,10 @@ export const defaultFFMpegArgs = writable("-lossless 1");
 export const corsAnywhereUrl = writable("");
 export const emojis = writable<Emoji[]>();
 
+// 機密情報　一週間で消える
 const cookieStoresRecord: Record<string, Writable<string>> = {
-  serverUrl, accessToken, defaultFFMpegArgs, corsAnywhereUrl
+  accessToken,
 };
-
 export const getCookie = () => {
   const cookies = document.cookie;
   if (cookies !== "") {
@@ -46,4 +46,14 @@ export const getCookie = () => {
     });
   }
   apiInit();
+}
+
+// 機密でもない情報　設定系
+const storageStoresRecord: Record<string, Writable<string>> = {
+  serverUrl, defaultFFMpegArgs, corsAnywhereUrl
+};
+for (const [key, store] of Object.entries(storageStoresRecord)) {
+  const saved = localStorage.getItem(key);
+  if (saved != null) store.set(saved);
+  store.subscribe(value => localStorage.setItem(key, value));
 }


### PR DESCRIPTION
- ファイルがセンシティブだった場合、登録UIに反映するようになりました。
- 非機密情報はlocalStorageに保存するように
  アクセストークンを除き、cookieの期限切れによる設定リセットがなくなります。
- ワンクリック変換機能
  cors-anywhereのURLを入力することで、画像のコピペやアップロードが不要な「ワンクリック変換」が可能になります。
  その絡みでUIのレイアウトの並びが変更されています。
- URLのクエリパラメータで設定を行えるように
  serverUrl、defaultFFMpegArgs、corsAnywhereUrlが対応しています。
  また、loadを指定すると現在の設定をURLに反映し、keep=1を指定するとクエリパラメータを消費しなくなります。
- 絵文字一括削除ツールを追加。消したい絵文字一覧が載っているテキストをコピペすることで絵文字をまとめて消せます。
  必要な権限が増えるので、従来のユーザーはトークンの再生成が必要です
- その他軽微な変更やリファクタリング